### PR TITLE
QuPath extensions for OMERO migrated - update link

### DIFF
--- a/docs/qupath.rst
+++ b/docs/qupath.rst
@@ -42,8 +42,9 @@ Setup
 -----
 
 - Download QuPath `v0.4.2 <https://github.com/qupath/qupath/releases/tag/v0.4.2>`_.
-- Download the `OMERO extension for QuPath <https://github.com/qupath/qupath-extension-omero/releases>`_ v0.3.0.
-- Install the OMERO extension as described in `qupath-omero-extension <https://github.com/qupath/qupath-extension-omero>`_.
+- Download the `OMERO extension for QuPath <https://github.com/qupath/qupath-extension-omero-web/releases>`_ v0.3.0.
+- Install the OMERO extension as described in `qupath-omero-extension <https://github.com/qupath/qupath-extension-omero-web>`_.
+- Note: the QuPath team is working on newer versions of the extensions under `qupath-omero-extension <https://github.com/qupath/qupath-extension-omero>`_ - these versions are currently under development and are meant only for testing.
 
 Step-by-step
 ------------

--- a/docs/qupath.rst
+++ b/docs/qupath.rst
@@ -118,12 +118,12 @@ Save detection ROIs using QuPath script
 
 #. Select several detection ROIs.
 
-#. Open the scripting dialog in QuPath ``Automate > Show script editor`` and paste into it the following code::
+#. Open the scripting dialog in QuPath ``Automate > Script editor`` and paste into it the following code::
 
       import qupath.lib.images.servers.omero.OmeroTools
       OmeroTools.writePathObjects(getSelectedObjects(), getCurrentServer())
 
-#. From the top menu, select ``Run > Run``. This saves the detection ROIs you selected in the ``Hierarchy`` tab into OMERO.
+#. Click ``Run``. This saves the detection ROIs you selected in the ``Hierarchy`` tab into OMERO.
 
 #. Go to OMERO.iviewer and refresh the image. Inspect the saved detection ROIs.
 

--- a/docs/qupath.rst
+++ b/docs/qupath.rst
@@ -43,7 +43,7 @@ Setup
 
 - Download QuPath `v0.4.2 <https://github.com/qupath/qupath/releases/tag/v0.4.2>`_.
 - Download the `OMERO extension for QuPath <https://github.com/qupath/qupath-extension-omero-web/releases>`_ v0.3.0.
-- Install the OMERO extension as described in `qupath-omero-extension <https://github.com/qupath/qupath-extension-omero-web>`_.
+- Install the OMERO extension as described in `qupath-omero-web-extension <https://github.com/qupath/qupath-extension-omero-web>`_.
 - Note: the QuPath team is working on newer versions of the extensions under `qupath-omero-extension <https://github.com/qupath/qupath-extension-omero>`_ - these versions are currently under development and are meant only for testing.
 
 Step-by-step

--- a/docs/qupath.rst
+++ b/docs/qupath.rst
@@ -41,8 +41,8 @@ Resources
 Setup
 -----
 
-- Download QuPath `v0.4.2 <https://github.com/qupath/qupath/releases/tag/v0.4.2>`_.
-- Download the `OMERO extension for QuPath <https://github.com/qupath/qupath-extension-omero-web/releases>`_ v0.3.0.
+- Download QuPath `v0.5.1 <https://github.com/qupath/qupath/releases/tag/v0.5.1>`_.
+- Download the `OMERO extension for QuPath <https://github.com/qupath/qupath-extension-omero-web/releases>`_ v0.4.0.
 - Install the OMERO extension as described in `qupath-omero-web-extension <https://github.com/qupath/qupath-extension-omero-web>`_.
 - Note: the QuPath team is working on newer versions of the extensions under `qupath-omero-extension <https://github.com/qupath/qupath-extension-omero>`_ - these versions are currently under development and are meant only for testing.
 


### PR DESCRIPTION
This PR:

- points to the ["...-web"](https://github.com/qupath/qupath-extension-omero-web) for qupath-omero-extension
- explains that the original https://github.com/qupath/qupath-extension-omero is now used for a new, unstable version developments



cc @jburel 